### PR TITLE
Clear warm starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV SCHEDULER_ROOT /ocs/adaptive_scheduler
 COPY requirements.pip $SCHEDULER_ROOT/requirements.pip
 RUN pip3 install numpy
 RUN pip3 install -r $SCHEDULER_ROOT/requirements.pip
+RUN pip3 install --ignore-installed six
 
 # copy the stuff
 COPY . $SCHEDULER_ROOT

--- a/adaptive_scheduler/kernel/fullscheduler_ortoolkit.py
+++ b/adaptive_scheduler/kernel/fullscheduler_ortoolkit.py
@@ -46,7 +46,7 @@ class FullScheduler_ortoolkit(SlicedIPScheduler_v2, SendMetricMixin):
     def __init__(self, kernel, compound_reservation_list,
                  globally_possible_windows_dict,
                  contractual_obligation_list,
-                 slice_size_seconds, mip_gap):
+                 slice_size_seconds, mip_gap, warm_starts):
         super().__init__(compound_reservation_list,
                          globally_possible_windows_dict,
                          contractual_obligation_list,
@@ -54,6 +54,7 @@ class FullScheduler_ortoolkit(SlicedIPScheduler_v2, SendMetricMixin):
         self.schedulerIDstring = 'SlicedIPSchedulerSparse'
         self.kernel = kernel
         self.mip_gap = mip_gap
+        self.warm_starts = warm_starts
         self.algorithm = ALGORITHMS[kernel.upper()]
 
     # A stub to get the RA/dec by request ID
@@ -148,7 +149,8 @@ class FullScheduler_ortoolkit(SlicedIPScheduler_v2, SendMetricMixin):
             solution_hints.append(r[4])
 
         # The warm-start hints (not supported in older ortools)
-        solver.SetHint(variables=scheduled_vars, values=solution_hints)
+        if self.warm_starts:
+            solver.SetHint(variables=scheduled_vars, values=solution_hints)
 
         # Constraint: One-of (eq 5)
         i = 0

--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -697,13 +697,13 @@ class SchedulerRunner(object):
             if self.scheduler_rerun_required() or self.first_run or rerun_required:
                 rerun_required = False
                 self.create_new_schedule(scheduler_run_start)
+                # Reset the warm starts flag back to the input setting at the end of each run
+                self.sched_params.warm_starts = self.warm_starts_setting
         except (ObservationPortalConnectionError, ScheduleException, EstimateExceededException) as eee:
             # Estimated run time was exceeded so exception was raised, or web resource failed
             # We should force a rerun in any case in case the network events and requests haven't changed
             rerun_required = True
             self.log.warning("Skipping Scheduling Run: {}".format(repr(eee)))
-        # Reset the warm starts flag back to the input setting at the end of each run
-        self.sched_params.warm_starts = self.warm_starts_setting
 
     def call_scheduler(self, scheduler_input, estimated_scheduler_end):
         self.log.info("Using a 'now' of %s", scheduler_input.scheduler_now)

--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -22,6 +22,7 @@ class SchedulerParameters(object):
                  no_singles=to_bool(os.getenv('NO_SINGLES', 'False')),
                  no_compounds=to_bool(os.getenv('NO_COMPOUNDS', 'False')),
                  no_rr=to_bool(os.getenv('NO_RAPID_RESPONSE', 'False')),
+                 warm_starts=to_bool(os.getenv('ENABLE_WARM_STARTS', 'False')),
                  timelimit_seconds=os.getenv('KERNEL_TIMELIMIT', None),
                  slicesize_seconds=int(os.getenv('MODEL_SLICESIZE', 300)),
                  horizon_days=float(os.getenv('MODEL_HORIZON', 7.0)),
@@ -50,6 +51,7 @@ class SchedulerParameters(object):
         self.no_singles = no_singles
         self.no_compounds = no_compounds
         self.no_rr = no_rr
+        self.warm_starts = warm_starts
         if timelimit_seconds:
             self.timelimit_seconds = float(timelimit_seconds)
         else:

--- a/as.py
+++ b/as.py
@@ -66,6 +66,8 @@ def parse_args(argv):
                             help="Ignore the 'and', 'oneof' and 'many' Request types")
     arg_parser.add_argument("--no_rr", type=bool, default=defaults.no_rr, dest='no_rr',
                             help="Treat Rapid Response Requests like Normal Requests")
+    arg_parser.add_argument("--warm_starts", type=bool, default=defaults.warm_starts, dest='warm_starts',
+                            help="Enable using warm start solutions in the scheduling kernel")
     arg_parser.add_argument("-o", "--run-once", type=bool, default=defaults.run_once,
                             help="Only run the scheduling loop once, then exit")
     arg_parser.add_argument("-k", "--kernel", type=str, default=defaults.kernel, choices=ALGORITHMS.keys(),

--- a/test/requires_third_party/fullscheduler_ortoolkit_helper.py
+++ b/test/requires_third_party/fullscheduler_ortoolkit_helper.py
@@ -94,23 +94,23 @@ class Fullscheduler_ortoolkit_helper(object):
         slice_size_seconds = 1
 
         self.fs1 = FullScheduler_ortoolkit(algorithm, [self.cr1, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs2 = FullScheduler_ortoolkit(algorithm, [self.cr1, self.cr4],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs3 = FullScheduler_ortoolkit(algorithm, [self.cr5],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs4 = FullScheduler_ortoolkit(algorithm, [self.cr8, self.cr6, self.cr7],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs5 = FullScheduler_ortoolkit(algorithm, [self.cr10, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs6 = FullScheduler_ortoolkit(algorithm, [self.cr11, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs7 = FullScheduler_ortoolkit(algorithm, [self.cr12],
-                                           self.gpw3, [], slice_size_seconds, 0.01)
+                                           self.gpw3, [], slice_size_seconds, 0.01, False)
         self.fs8 = FullScheduler_ortoolkit(algorithm, [self.cr13, self.cr14, self.cr15, self.cr16],
-                                           self.gpw4, [], slice_size_seconds, 0.01)
+                                           self.gpw4, [], slice_size_seconds, 0.01, False)
         self.fs9 = FullScheduler_ortoolkit(algorithm, [self.cr17, self.cr18, self.cr19],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs10 = FullScheduler_ortoolkit(algorithm, [self.cr20, self.cr21, self.cr22],
-                                            self.gpw2, [], slice_size_seconds, 0.01)
+                                            self.gpw2, [], slice_size_seconds, 0.01, False)
 

--- a/test/requires_third_party/test_fullscheduler_glpk.py
+++ b/test/requires_third_party/test_fullscheduler_glpk.py
@@ -89,7 +89,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
     def test_schedule_triple_oneof(self):
         slice_size_seconds = 1
         fs = FullScheduler_ortoolkit(self.algorithm, [self.cr9],
-                                     self.gpw2, [], slice_size_seconds, 0.01)
+                                     self.gpw2, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
         # only one should be scheduled
 
@@ -109,7 +109,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 90000, 'type': 'start'},
                                 {'time': 201000, 'type': 'end'}])
         slice_size_seconds = 300
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], slice_size_seconds, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
 
     def test_schedule_all_gaw(self):
@@ -126,7 +126,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([])  # [{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -139,7 +139,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -152,7 +152,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -165,7 +165,7 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -178,5 +178,5 @@ class TestFullScheduler_glpk(Fullscheduler_ortoolkit_helper):
         gpw = {}
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         fs.schedule_all()

--- a/test/requires_third_party/test_fullscheduler_gurobi.py
+++ b/test/requires_third_party/test_fullscheduler_gurobi.py
@@ -111,25 +111,25 @@ class TestFullScheduler_gurobi(object):
         slice_size_seconds = 1
 
         self.fs1 = FullScheduler_ortoolkit('GUROBI', [self.cr1, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs2 = FullScheduler_ortoolkit('GUROBI', [self.cr1, self.cr4],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs3 = FullScheduler_ortoolkit('GUROBI', [self.cr5],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs4 = FullScheduler_ortoolkit('GUROBI', [self.cr8, self.cr6, self.cr7],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs5 = FullScheduler_ortoolkit('GUROBI', [self.cr10, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs6 = FullScheduler_ortoolkit('GUROBI', [self.cr11, self.cr2, self.cr3],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs7 = FullScheduler_ortoolkit('GUROBI', [self.cr12],
-                                           self.gpw3, [], slice_size_seconds, 0.01)
+                                           self.gpw3, [], slice_size_seconds, 0.01, False)
         self.fs8 = FullScheduler_ortoolkit('GUROBI', [self.cr13, self.cr14, self.cr15, self.cr16],
-                                           self.gpw4, [], slice_size_seconds, 0.01)
+                                           self.gpw4, [], slice_size_seconds, 0.01, False)
         self.fs9 = FullScheduler_ortoolkit('GUROBI', [self.cr17, self.cr18, self.cr19],
-                                           self.gpw2, [], slice_size_seconds, 0.01)
+                                           self.gpw2, [], slice_size_seconds, 0.01, False)
         self.fs10 = FullScheduler_ortoolkit('GUROBI', [self.cr20, self.cr21, self.cr22],
-                                            self.gpw2, [], slice_size_seconds, 0.01)
+                                            self.gpw2, [], slice_size_seconds, 0.01, False)
 
     # This is testing that we schedule earlier rather than later if given the choice
     def test_schedule_early(self):
@@ -197,7 +197,7 @@ class TestFullScheduler_gurobi(object):
     def test_schedule_triple_oneof(self):
         slice_size_seconds = 1
         fs = FullScheduler_ortoolkit('GUROBI', [self.cr9],
-                                     self.gpw2, [], slice_size_seconds, 0.01)
+                                     self.gpw2, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
         # only one should be scheduled
 
@@ -217,7 +217,7 @@ class TestFullScheduler_gurobi(object):
         gpw['goo'] = Intervals([{'time': 90000, 'type': 'start'},
                                 {'time': 201000, 'type': 'end'}])
         slice_size_seconds = 300
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], slice_size_seconds, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
 
     def test_schedule_all_gaw(self):
@@ -234,7 +234,7 @@ class TestFullScheduler_gurobi(object):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([])  # [{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -247,7 +247,7 @@ class TestFullScheduler_gurobi(object):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -260,7 +260,7 @@ class TestFullScheduler_gurobi(object):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -273,7 +273,7 @@ class TestFullScheduler_gurobi(object):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -286,5 +286,5 @@ class TestFullScheduler_gurobi(object):
         gpw = {}
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit('GUROBI', [cr], gpw, [], 60, 0.01, False)
         fs.schedule_all()

--- a/test/test_fullscheduler_cbc.py
+++ b/test/test_fullscheduler_cbc.py
@@ -97,7 +97,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
     def test_schedule_triple_oneof(self):
         slice_size_seconds = 1
         fs = FullScheduler_ortoolkit(self.algorithm, [self.cr9],
-                                     self.gpw2, [], slice_size_seconds, 0.01)
+                                     self.gpw2, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
         # only one should be scheduled
 
@@ -117,7 +117,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 90000, 'type': 'start'},
                                 {'time': 201000, 'type': 'end'}])
         slice_size_seconds = 300
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], slice_size_seconds, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], slice_size_seconds, 0.01, False)
         fs.schedule_all()
 
     def test_schedule_all_gaw(self):
@@ -134,7 +134,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([])  # [{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -147,7 +147,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['foo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['goo']))
@@ -160,7 +160,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -173,7 +173,7 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw['foo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
         gpw['goo'] = Intervals([{'time': 1500, 'type': 'start'}, {'time': 2000, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         schedule = fs.schedule_all()
         print(schedule)
         assert_equal(1, len(schedule['foo']))
@@ -186,5 +186,5 @@ class TestFullScheduler_cbc(Fullscheduler_ortoolkit_helper):
         gpw = {}
         gpw['goo'] = Intervals([{'time': 250, 'type': 'start'}, {'time': 750, 'type': 'end'}])
 
-        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01)
+        fs = FullScheduler_ortoolkit(self.algorithm, [cr], gpw, [], 60, 0.01, False)
         fs.schedule_all()


### PR DESCRIPTION
This adds an input parameter for enabling warm start solutions in general, and then also clears the usage of warm starts for a single run whenever the network events have changed.