### PR TITLE
store input and output in S3 bucket optionally

### DIFF
--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -6,6 +6,7 @@ from adaptive_scheduler.observation_portal_connections import ObservationPortalC
 import os
 import logging
 import pickle
+import boto3
 from datetime import datetime, timedelta
 
 
@@ -31,6 +32,7 @@ class SchedulerParameters(object):
                  input_file_name=os.getenv('SCHEDULER_INPUT_FILE', None),
                  pickle=to_bool(os.getenv('SAVE_PICKLE_INPUT_FILES', 'False')),
                  mip_gap=float(os.getenv('KERNEL_MIPGAP', 0.01)),
+                 s3_bucket=os.getenv('AWS_BUCKET', ''),
                  save_output=to_bool(os.getenv('SAVE_JSON_OUTPUT_FILES', 'False')),
                  request_logs=to_bool(os.getenv('SAVE_PER_REQUEST_LOGS', 'False')),
                  observation_portal_url=os.getenv('OBSERVATION_PORTAL_URL', 'http://127.0.0.1:8000'),
@@ -69,6 +71,7 @@ class SchedulerParameters(object):
         self.normal_runtime_seconds = normal_runtime_seconds
         self.rr_runtime_seconds = rr_runtime_seconds
         self.mip_gap = mip_gap
+        self.s3_bucket = s3_bucket
         self.ignore_ipp = ignore_ipp
         self.telescope_class = telescope_class
         self.observation_portal_url = observation_portal_url
@@ -176,7 +179,8 @@ class SchedulingInputFactory(object):
         if self.input_provider.sched_params.pickle:
             SchedulingInputUtils.write_input_to_file(self.input_provider, rr_scheduler_now,
                                                      rr_resource_usage_snapshot, rr_estimated_runtime,
-                                                     self.model_builder)
+                                                     self.model_builder,
+                                                     self.input_provider.sched_params.s3_bucket)
 
         return self._create_scheduling_input(self.input_provider, False, block_schedule=rr_schedule)
 
@@ -235,7 +239,7 @@ class SchedulingInputUtils(SendMetricMixin):
 
     @staticmethod
     def write_input_to_file(normal_input_provider, rr_scheduler_now, rr_resource_usage_snapshot,
-                            rr_estimated_scheduler_runtime, model_builder,
+                            rr_estimated_scheduler_runtime, model_builder, s3_bucket,
                             output_path='/data/adaptive_scheduler/input_states/'):
         output = {
             'sched_params': normal_input_provider.sched_params,
@@ -254,15 +258,26 @@ class SchedulingInputUtils(SendMetricMixin):
             'proposals_by_id': model_builder.proposals_by_id,
             'semester_details': model_builder.semester_details
         }
+        day_timestamp = datetime.utcnow().strftime('%Y-%m-%d')
         file_timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-        filename = os.path.join(output_path, 'scheduling_input_{}.pickle'.format(file_timestamp))
-        outfile = open(filename, 'wb')
-        try:
-            pickle.dump(output, outfile)
-        except pickle.PickleError as pe:
-            print(pe)
+        filename = 'scheduling_input_{}.pickle'.format(file_timestamp)
+        filepath = os.path.join(output_path, filename)
 
-        outfile.close()
+        # If an S3 bucket is configured, attempt to store input files in the bucket in a daydir
+        if s3_bucket:
+            serialized_output = pickle.dumps(output)
+            try:
+                s3 = boto3.client('s3')
+                s3.put_object(Bucket=s3_bucket, Key=f'{day_timestamp}/{filename}', Body=serialized_output)
+            except Exception as e:
+                logging.warning(f"Failed to store input file in S3 bucket: {repr(e)}")
+        else:
+            outfile = open(filepath, 'wb')
+            try:
+                pickle.dump(output, outfile)
+            except pickle.PickleError as pe:
+                print(pe)
+            outfile.close()
 
 
 class SchedulingInput(object):

--- a/requirements.pip
+++ b/requirements.pip
@@ -13,6 +13,7 @@ lcogt-logging
 python-dateutil
 unidecode<1.2.0
 elasticsearch<6.0,>=5.0
+boto3==1.17.20
 six
 
 # 2) Testing/debugging dependencies


### PR DESCRIPTION
I realized for the production deploy that the input/output files we store take up many Gb per day, so it's not realistic to store those in the container, or even in a persistent volume. 

Jesus showed me some Ira docs talking about how we shouldn't use persistent volumes and S3 is usually the better choice, so I added in the option to set an S3 bucket (and set the AWS S3 variables in your environment) to store the input and output files in daydirs in that S3 bucket rather than on the local filesystem.

This has been tested on the dev cluster, writing to the scheduler-lco-global bucket. 