### PR TITLE
Round running request end time up to second boundary to fix aborts

### DIFF
--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -235,6 +235,10 @@ class ObservationScheduleInterface(object):
         for block in observations:
             block['start'] = parse(block['start'], ignoretz=True)
             block['end'] = parse(block['end'], ignoretz=True)
+            # Add a second if there are any microseconds in the existing end time,
+            # because this is used for our next schedule start time.
+            if block['end'].microsecond:
+                block['end'] = block['end'].replace(microsecond=0) + timedelta(seconds=1)
 
         return observations
 


### PR DESCRIPTION
So I found a way to somewhat reproduce the abort issue on my local ocs_example apps. The process was to get a few requests scheduled, then take the first one, make it current and in progress, and update its end time to have fractional seconds. Then wait 1+ runs until something was to be scheduled immediately after it (usually just 1 run). 

The bug was not in the main cancel by time range code (that code sent the microseconds just fine), but actual earlier on where we find and abort running requests that are overlapped by the current schedule (this part of the code is meant to clean up requests that have errored out, but it also aborts ones that overlap with the current schedule). 

[This code](https://github.com/observatorycontrolsystem/adaptive_scheduler/blob/main/adaptive_scheduler/scheduler.py#L805) compared the currently running observations end time against the first new scheduled observations start time, and if there was overlap aborted the old running obs. The scheduler schedules everything on the second boundary, and actually converts all start times into normalized seconds since the start of the semester. This conversion to seconds and back during scheduling looses the microseconds, so when we had a running obs ending at say 45.555, the new schedule would be created at 45.555, but in the calculation about, we would think the start was actually just at 45, before the currently running obs so the current obs would get aborted.

There are a lot of different places where this could be fixed, but I picked the place that seemed the simplest and least intrusive. This PR just rounds up the next second boundary on the end time of running observations as they are read in if they have nonzero microseconds. This in turn will cause the new schedule to schedule on that second onward, which is guaranteed to be after the actual end time of the running observation, so the running observation should no longer be aborted. We could also  / instead restrict observation end times to be whole seconds in the observation portal, but we don't really have any need to impose that restriction since this is purely a scheduler implementation detail that it schedules on whole seconds. So this change still allows observations to have fractional second times, so some other scheduler implementation could work with that if it wants.