### PR TITLE
change telescope_class parameter to be telescope_classes and take a c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optional prerequisites can be skipped for reduced functionality.
 |                        | `TIME_BETWEEN_RUNS`             | Seconds to sleep between each scheduling loop          | 60.0                                                 |
 |                        | `IGNORE_IPP_VALUES`             | If True, ignore IPP values when considering request priority          | `False`                                                   |
 |                        | `INITIAL_PER_RESERVATION_SAVE_TIME`             | Initial estimate of time taken per reservation to save to the web portal          | 60.0                                                 |
-|                        | `TELESCOPE_CLASS`             | Restrict the scheduler to only operate on a single telescope class (e.g. `1m0`)       | `all`                                                 |
+|                        | `TELESCOPE_CLASSES`             | Restrict the scheduler to only operate on the specified telescope classes (comma delimited) (e.g. `1m0,2m0`). Default empty string means all telescope classes.       | ``                                                 |
 |                        | `INITIAL_NORMAL_RUNTIME`             | Initial estimate of duration of normal scheduling cycle in seconds         | 360.0                                                 |
 |                        | `INITIAL_RAPID_RESPONSE_RUNTIME`  | Initial estimate of duration of rapid response scheduling cycle in seconds      | 120.0                                                 |
 | Debugging Settings     | `SAVE_PICKLE_INPUT_FILES`     | If True, stores pickled scheduler input files each run in `/data/adaptive_scheduler/input_states` | `False`                                                   |

--- a/adaptive_scheduler/configdb_connections.py
+++ b/adaptive_scheduler/configdb_connections.py
@@ -96,7 +96,7 @@ class ConfigDBInterface(SendMetricMixin):
             for instrument in json_results['results']:
                 split_string = instrument['__str__'].lower().split('.')
                 telescope_class = split_string[2][:3]
-                if telescope_class.lower() in self.telescope_classes.lower():
+                if telescope_class in self.telescope_classes:
                     instruments.append(instrument)
             return instruments
         else:
@@ -298,7 +298,7 @@ class ConfigDBInterface(SendMetricMixin):
             for enclosure in site['enclosure_set']:
                 for telescope in enclosure['telescope_set']:
                     telescope_class = telescope['code'][:3]
-                    if not self.telescope_classes or telescope_class.lower() in self.telescope_classes.lower():
+                    if not self.telescope_classes or telescope_class in self.telescope_classes:
                         name = '.'.join([telescope['code'], enclosure['code'], site['code']])
                         active = telescope['active'] and enclosure['active'] and site['active']
                         telescope_info[name] = {

--- a/adaptive_scheduler/interfaces.py
+++ b/adaptive_scheduler/interfaces.py
@@ -154,11 +154,11 @@ class NetworkInterface(object):
             logger.warn("Failed to check the last_changed time properly: {}".format(repr(e)))
             return True
 
-    def get_all_request_groups(self, start, end, telescope_class):
+    def get_all_request_groups(self, start, end, telescope_classes):
         '''Get all user requests waiting for scheduling between
         start and end date, potentially for a single telescope class
         '''
-        return self.observation_portal_interface.get_all_request_groups(start, end, telescope_class)
+        return self.observation_portal_interface.get_all_request_groups(start, end, telescope_classes)
 
     def cancel(self, cancelation_date_list_by_resource, include_rr, include_normal):
         ''' Cancel the current scheduler between start and end
@@ -216,7 +216,7 @@ class CachedInputNetworkInterface(object):
         '''
         return True
 
-    def get_all_request_groups(self, start, end, telescope_class):
+    def get_all_request_groups(self, start, end, telescope_classes):
         '''Get all user requests waiting for scheduling as loaded in from the input file
         '''
         return self.json_request_group_list

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -83,13 +83,14 @@ class ObservationPortalInterface(SendMetricMixin):
 
     @timeit
     @metric_timer('requestdb.get_requests', num_requests=len)
-    def get_all_request_groups(self, start, end, telescope_classes=[]):
+    def get_all_request_groups(self, start, end, telescope_classes=None):
         ''' Get all user requests waiting for scheduling between
             start and end date, potentially for a single telescope class
         '''
         requests_url = self.obs_portal_url + '/api/requestgroups/schedulable_requests/?start=' + start.isoformat() + '&end=' + end.isoformat()
-        for telescope_class in telescope_classes:
-            requests_url += '&telescope_class=' + telescope_class
+        if telescope_classes:
+            for telescope_class in telescope_classes:
+                requests_url += '&telescope_class=' + telescope_class
         self.log.info("Getting schedulable requests from: {}".format(requests_url))
         try:
             response = requests.get(requests_url, headers=self.headers, timeout=180)

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -83,7 +83,7 @@ class ObservationPortalInterface(SendMetricMixin):
 
     @timeit
     @metric_timer('requestdb.get_requests', num_requests=len)
-    def get_all_request_groups(self, start, end, telescope_classes=[]]):
+    def get_all_request_groups(self, start, end, telescope_classes=[]):
         ''' Get all user requests waiting for scheduling between
             start and end date, potentially for a single telescope class
         '''

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -89,7 +89,8 @@ class ObservationPortalInterface(SendMetricMixin):
         '''
         requests_url = self.obs_portal_url + '/api/requestgroups/schedulable_requests/?start=' + start.isoformat() + '&end=' + end.isoformat()
         if telescope_classes:
-            requests_url += '&telescope_classes=' + telescope_classes
+            for telescope_class in telescope_classes.split(','):
+                requests_url += '&telescope_class=' + telescope_class
         self.log.info("Getting schedulable requests from: {}".format(requests_url))
         try:
             response = requests.get(requests_url, headers=self.headers, timeout=180)

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -83,13 +83,13 @@ class ObservationPortalInterface(SendMetricMixin):
 
     @timeit
     @metric_timer('requestdb.get_requests', num_requests=len)
-    def get_all_request_groups(self, start, end, telescope_class='all'):
+    def get_all_request_groups(self, start, end, telescope_classes=''):
         ''' Get all user requests waiting for scheduling between
             start and end date, potentially for a single telescope class
         '''
         requests_url = self.obs_portal_url + '/api/requestgroups/schedulable_requests/?start=' + start.isoformat() + '&end=' + end.isoformat()
-        if not telescope_class.lower() == 'all':
-            requests_url += '&telescope_class=' + telescope_class
+        if telescope_classes:
+            requests_url += '&telescope_classes=' + telescope_classes
         self.log.info("Getting schedulable requests from: {}".format(requests_url))
         try:
             response = requests.get(requests_url, headers=self.headers, timeout=180)

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -83,14 +83,13 @@ class ObservationPortalInterface(SendMetricMixin):
 
     @timeit
     @metric_timer('requestdb.get_requests', num_requests=len)
-    def get_all_request_groups(self, start, end, telescope_classes=''):
+    def get_all_request_groups(self, start, end, telescope_classes=[]]):
         ''' Get all user requests waiting for scheduling between
             start and end date, potentially for a single telescope class
         '''
         requests_url = self.obs_portal_url + '/api/requestgroups/schedulable_requests/?start=' + start.isoformat() + '&end=' + end.isoformat()
-        if telescope_classes:
-            for telescope_class in telescope_classes.split(','):
-                requests_url += '&telescope_class=' + telescope_class
+        for telescope_class in telescope_classes:
+            requests_url += '&telescope_class=' + telescope_class
         self.log.info("Getting schedulable requests from: {}".format(requests_url))
         try:
             response = requests.get(requests_url, headers=self.headers, timeout=180)

--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -40,7 +40,7 @@ class SchedulerParameters(object):
                  configdb_url=os.getenv('CONFIGDB_URL', 'http://127.0.0.1:7000'),
                  downtime_url=os.getenv('DOWNTIME_URL', 'http://127.0.0.1:7500'),
                  elasticsearch_url=os.getenv('ELASTICSEARCH_URL', ''),
-                 telescope_class=os.getenv('TELESCOPE_CLASS', 'all'),
+                 telescope_classes=os.getenv('TELESCOPE_CLASSES', ''),
                  elasticsearch_index=os.getenv('ELASTICSEARCH_INDEX', 'live-telemetry'),
                  elasticsearch_excluded_observatories=os.getenv('ELASTICSEARCH_EXCLUDED_OBSERVATORIES', ''),
                  profiling_enabled=to_bool(os.getenv('CPROFILE_ENABLED', 'False')),
@@ -75,7 +75,7 @@ class SchedulerParameters(object):
         self.mip_gap = mip_gap
         self.s3_bucket = s3_bucket
         self.ignore_ipp = ignore_ipp
-        self.telescope_class = telescope_class
+        self.telescope_classes = telescope_classes
         self.observation_portal_url = observation_portal_url
         self.configdb_url = configdb_url
         self.downtime_url = downtime_url
@@ -420,7 +420,7 @@ class SchedulingInputProvider(object):
                                                                 min(now + timedelta(
                                                                     days=self.sched_params.horizon_days),
                                                                     semester_details['end']),
-                                                                self.sched_params.telescope_class)
+                                                                self.sched_params.telescope_classes)
         logging.getLogger(__name__).warning("_get_json_request_group_list got {} rgs".format(len(rg_list)))
 
         return rg_list
@@ -430,7 +430,7 @@ class SchedulingInputProvider(object):
         resources = []
         for resource_name, resource in self.network_model.items():
             telescope_class = resource_name[:3].lower()  # telescope class is first 3 characters of the resource
-            if not resource['events'] and self.sched_params.telescope_class.lower() in ['all', telescope_class]:
+            if not resource['events']:
                 resources.append(resource_name)
 
         return resources

--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -75,7 +75,10 @@ class SchedulerParameters(object):
         self.mip_gap = mip_gap
         self.s3_bucket = s3_bucket
         self.ignore_ipp = ignore_ipp
-        self.telescope_classes = telescope_classes
+        if telescope_classes:
+            self.telescope_classes = telescope_classes.split(',')
+        else:
+            self.telescope_classes = []
         self.observation_portal_url = observation_portal_url
         self.configdb_url = configdb_url
         self.downtime_url = downtime_url
@@ -429,7 +432,6 @@ class SchedulingInputProvider(object):
         # perform filtering out telescope classes here for now, but longterm should happen when querying requests
         resources = []
         for resource_name, resource in self.network_model.items():
-            telescope_class = resource_name[:3].lower()  # telescope class is first 3 characters of the resource
             if not resource['events']:
                 resources.append(resource_name)
 

--- a/as.py
+++ b/as.py
@@ -82,8 +82,8 @@ def parse_args(argv):
                             help="Enable storing scheduling run output in a json file")
     arg_parser.add_argument("--request_logs", type=bool, default=defaults.request_logs, dest='request_logs',
                             help="Enable saving the per-request log files")
-    arg_parser.add_argument("--telescope_class", type=str, default=defaults.telescope_class,
-                            help="Only schedule observations on the specified telescope_class. Expects 3 character telescope class, default is 'all'")
+    arg_parser.add_argument("--telescope_classes", type=str, default=defaults.telescope_classes,
+                            help="Only schedule observations on the specified telescope_classes. Expects 3 character telescope classes comma delimited. If not specified, default is all classes.")
     arg_parser.add_argument("--downtime_url", type=str, dest='downtime_url',
                             help="Downtime endpoint url", default=defaults.downtime_url)
     arg_parser.add_argument("--elasticsearch_url", type=str, dest='elasticsearch_url',
@@ -150,7 +150,7 @@ def main(argv):
 
     schedule_interface = ObservationScheduleInterface(host=sched_params.observation_portal_url)
     observation_portal_interface = ObservationPortalInterface(sched_params.observation_portal_url)
-    configdb_interface = ConfigDBInterface(configdb_url=sched_params.configdb_url)
+    configdb_interface = ConfigDBInterface(configdb_url=sched_params.configdb_url, telescope_classes=sched_params.telescope_classes)
     network_state_interface = Network(configdb_interface, sched_params)
     network_interface = NetworkInterface(schedule_interface, observation_portal_interface, network_state_interface,
                                          configdb_interface)

--- a/as.py
+++ b/as.py
@@ -82,7 +82,7 @@ def parse_args(argv):
                             help="Enable storing scheduling run output in a json file")
     arg_parser.add_argument("--request_logs", type=bool, default=defaults.request_logs, dest='request_logs',
                             help="Enable saving the per-request log files")
-    arg_parser.add_argument("--telescope_classes", type=str, default=defaults.telescope_classes,
+    arg_parser.add_argument("--telescope_classes", type=str, default=','.join(defaults.telescope_classes),
                             help="Only schedule observations on the specified telescope_classes. Expects 3 character telescope classes comma delimited. If not specified, default is all classes.")
     arg_parser.add_argument("--downtime_url", type=str, dest='downtime_url',
                             help="Downtime endpoint url", default=defaults.downtime_url)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -399,7 +399,7 @@ class TestModelBuilder(object):
         self.id = 2
         self.state = 'PENDING'
 
-        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='',
+        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='', telescope_classes='',
                                                                    active_instruments_file='test/active_instruments.json',
                                                                    telescopes_file='test/telescopes.json'))
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -399,7 +399,7 @@ class TestModelBuilder(object):
         self.id = 2
         self.state = 'PENDING'
 
-        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='', telescope_classes='',
+        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='', telescope_classes=[]],
                                                                    active_instruments_file='test/active_instruments.json',
                                                                    telescopes_file='test/telescopes.json'))
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -399,7 +399,7 @@ class TestModelBuilder(object):
         self.id = 2
         self.state = 'PENDING'
 
-        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='', telescope_classes=[]],
+        self.mb = ModelBuilder(mock.MagicMock(), ConfigDBInterface(configdb_url='', telescope_classes=[],
                                                                    active_instruments_file='test/active_instruments.json',
                                                                    telescopes_file='test/telescopes.json'))
 

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -21,7 +21,7 @@ from adaptive_scheduler.configdb_connections import ConfigDBInterface
 class TestOfflineResourceMonitor(object):
 
     def test_telescope_is_offline(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
                                                                               telescopes_file='test/telescopes_sqa_offline.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -29,7 +29,7 @@ class TestOfflineResourceMonitor(object):
         eq_(event['0m8a.doma.sqa'].type, 'OFFLINE')
 
     def test_telescope_is_online(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
                                                                               telescopes_file='test/telescopes.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -45,7 +45,7 @@ class TestAvailableForSchedulingMonitor(object):
 
     def setUp(self):
         self.monitor = AvailableForScheduling(
-            configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
+            configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
                                                  telescopes_file='test/telescopes.json',
                                                  active_instruments_file='test/active_instruments.json'),
             elasticsearch_url='',

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -21,7 +21,7 @@ from adaptive_scheduler.configdb_connections import ConfigDBInterface
 class TestOfflineResourceMonitor(object):
 
     def test_telescope_is_offline(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='',
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
                                                                               telescopes_file='test/telescopes_sqa_offline.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -29,7 +29,7 @@ class TestOfflineResourceMonitor(object):
         eq_(event['0m8a.doma.sqa'].type, 'OFFLINE')
 
     def test_telescope_is_online(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='',
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
                                                                               telescopes_file='test/telescopes.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -45,7 +45,7 @@ class TestAvailableForSchedulingMonitor(object):
 
     def setUp(self):
         self.monitor = AvailableForScheduling(
-            configdb_interface=ConfigDBInterface(configdb_url='',
+            configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes='',
                                                  telescopes_file='test/telescopes.json',
                                                  active_instruments_file='test/active_instruments.json'),
             elasticsearch_url='',

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -21,7 +21,7 @@ from adaptive_scheduler.configdb_connections import ConfigDBInterface
 class TestOfflineResourceMonitor(object):
 
     def test_telescope_is_offline(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[],
                                                                               telescopes_file='test/telescopes_sqa_offline.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -29,7 +29,7 @@ class TestOfflineResourceMonitor(object):
         eq_(event['0m8a.doma.sqa'].type, 'OFFLINE')
 
     def test_telescope_is_online(self):
-        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
+        monitor = OfflineResourceMonitor(configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[],
                                                                               telescopes_file='test/telescopes.json',
                                                                               active_instruments_file='test/active_instruments.json'))
         event = monitor.monitor()
@@ -45,7 +45,7 @@ class TestAvailableForSchedulingMonitor(object):
 
     def setUp(self):
         self.monitor = AvailableForScheduling(
-            configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[]],
+            configdb_interface=ConfigDBInterface(configdb_url='', telescope_classes=[],
                                                  telescopes_file='test/telescopes.json',
                                                  active_instruments_file='test/active_instruments.json'),
             elasticsearch_url='',

--- a/test/test_observations.py
+++ b/test/test_observations.py
@@ -21,7 +21,7 @@ class TestObservations(object):
         # Metadata missing proposal and tag parameters
         self.proposal = Proposal(pi='Eric Saunders')
 
-        self.configdb_interface = ConfigDBInterface(configdb_url='', telescope_classes=[]],
+        self.configdb_interface = ConfigDBInterface(configdb_url='', telescope_classes=[],
                                                     telescopes_file='test/telescopes.json',
                                                     active_instruments_file='test/active_instruments.json')
 

--- a/test/test_observations.py
+++ b/test/test_observations.py
@@ -21,7 +21,7 @@ class TestObservations(object):
         # Metadata missing proposal and tag parameters
         self.proposal = Proposal(pi='Eric Saunders')
 
-        self.configdb_interface = ConfigDBInterface(configdb_url='',
+        self.configdb_interface = ConfigDBInterface(configdb_url='', telescope_classes='',
                                                     telescopes_file='test/telescopes.json',
                                                     active_instruments_file='test/active_instruments.json')
 

--- a/test/test_observations.py
+++ b/test/test_observations.py
@@ -21,7 +21,7 @@ class TestObservations(object):
         # Metadata missing proposal and tag parameters
         self.proposal = Proposal(pi='Eric Saunders')
 
-        self.configdb_interface = ConfigDBInterface(configdb_url='', telescope_classes='',
+        self.configdb_interface = ConfigDBInterface(configdb_url='', telescope_classes=[]],
                                                     telescopes_file='test/telescopes.json',
                                                     active_instruments_file='test/active_instruments.json')
 


### PR DESCRIPTION
…omma delimited list. Fix how it is applied.

This changes the telescope_class parameter to be telescope_classes and sends a comma delimited list of telescope_classes to the updated schedulable_requests endpoint: https://github.com/observatorycontrolsystem/observation-portal/pull/190. 

Also fixed how the telescope_classes were applied. Previously, they were working to filter requests received and where requested were scheduled, but non-included telescope_classes would still have their scheduled cancelled by the scheduler. Here I've moved where we do the filtering out of telescope_classes into the configdb_connection code, so as close to the source as possible. This prevents any part of the scheduler from operating on non-included telescope_classes.

I've tested this branch along with the corresponding obs portal branch on my local ocs_example.