### PR TITLE
Add setting rise-set to cache after computing it in main thread

### DIFF
--- a/adaptive_scheduler/kernel_mappings.py
+++ b/adaptive_scheduler/kernel_mappings.py
@@ -378,6 +378,13 @@ def filter_on_visibility(rgs, visibility_for_resource, downtime_intervals, semes
                     cache_key]
                 local_cache[cache_key] = get_rise_set_timepoint_intervals(rise_set_target, visibility, max_airmass,
                                                                           min_lunar_distance)
+                # save the newly calculated rise-set values into the redis cache for next restart
+                try:
+                    redis.set(cache_key, pickle.dumps(local_cache[cache_key]))
+                except Exception:
+                    log.warn(
+                    'Failed to save rise_set intervals into redis. Please check that redis is online.')
+
 
     # now that we have all the rise_set intervals in local cache, perform the visibility filter on the requests
     for rg in rgs:


### PR DESCRIPTION
I think this was the missing piece that was causing us to take a while to re-calculate rise-sets after container restart. I think historically it could take like 40min+ or an hour or so to calculate all rise-sets for the current semester for the scheduler and cache them. Since our threaded rise-set calculations have a 5 minute time-out before moving towards computing them in the main thread, I suspect that with the few runs we've done, we hit that 5 minutes and then the remainder of rise-sets were calculated in the main thread and not saved in redis, so they would need to be calculated again on container restart. This PR just saves the main thread calculated rise-sets into redis if possible.