### PR TITLE
Add telescope_classes to input and output saved filenames

### DIFF
--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -209,7 +209,11 @@ class Scheduler(SendMetricMixin):
             now = datetime.utcnow()
             day_timestamp = now.strftime('%Y-%m-%d')
             file_timestamp = now.strftime('%Y%m%d%H%M%S')
-            filename = '{}_{}_schedule_{}.json'.format(schedule_type, '_'.join(self.sched_params.telescope_classes), file_timestamp)
+            if self.sched_params.telescope_classes:
+                telescope_class_str = '_'.join(self.sched_params.telescope_classes)
+            else:
+                telescope_class_str = 'all'
+            filename = '{}_{}_schedule_{}.json'.format(schedule_type, telescope_class_str, file_timestamp)
 
             # If an S3 bucket is configured, attempt to store output files in the bucket in a daydir
             if self.sched_params.s3_bucket:

--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -209,7 +209,7 @@ class Scheduler(SendMetricMixin):
             now = datetime.utcnow()
             day_timestamp = now.strftime('%Y-%m-%d')
             file_timestamp = now.strftime('%Y%m%d%H%M%S')
-            filename = '{}_schedule_{}.json'.format(schedule_type, file_timestamp)
+            filename = '{}_{}_schedule_{}.json'.format(schedule_type, '_'.join(self.sched_params.telescope_classes), file_timestamp)
 
             # If an S3 bucket is configured, attempt to store output files in the bucket in a daydir
             if self.sched_params.s3_bucket:

--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -185,7 +185,8 @@ class SchedulingInputFactory(object):
             SchedulingInputUtils.write_input_to_file(self.input_provider, rr_scheduler_now,
                                                      rr_resource_usage_snapshot, rr_estimated_runtime,
                                                      self.model_builder,
-                                                     self.input_provider.sched_params.s3_bucket)
+                                                     self.input_provider.sched_params.s3_bucket,
+                                                     self.input_provider.sched_params.telescope_classes)
 
         return self._create_scheduling_input(self.input_provider, False, block_schedule=rr_schedule)
 
@@ -244,7 +245,7 @@ class SchedulingInputUtils(SendMetricMixin):
 
     @staticmethod
     def write_input_to_file(normal_input_provider, rr_scheduler_now, rr_resource_usage_snapshot,
-                            rr_estimated_scheduler_runtime, model_builder, s3_bucket,
+                            rr_estimated_scheduler_runtime, model_builder, s3_bucket, telescope_classes,
                             output_path='/data/adaptive_scheduler/input_states/'):
         output = {
             'sched_params': normal_input_provider.sched_params,
@@ -265,7 +266,7 @@ class SchedulingInputUtils(SendMetricMixin):
         }
         day_timestamp = datetime.utcnow().strftime('%Y-%m-%d')
         file_timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-        filename = 'scheduling_input_{}.pickle'.format(file_timestamp)
+        filename = 'scheduling_input_{}_{}.pickle'.format('_'.join(telescope_classes), file_timestamp)
         filepath = os.path.join(output_path, filename)
 
         # If an S3 bucket is configured, attempt to store input files in the bucket in a daydir

--- a/adaptive_scheduler/scheduler_input.py
+++ b/adaptive_scheduler/scheduler_input.py
@@ -266,7 +266,11 @@ class SchedulingInputUtils(SendMetricMixin):
         }
         day_timestamp = datetime.utcnow().strftime('%Y-%m-%d')
         file_timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-        filename = 'scheduling_input_{}_{}.pickle'.format('_'.join(telescope_classes), file_timestamp)
+        if telescope_classes:
+            telescope_class_str = '_'.join(telescope_classes)
+        else:
+            telescope_class_str = 'all'
+        filename = 'scheduling_input_{}_{}.pickle'.format(telescope_class_str, file_timestamp)
         filepath = os.path.join(output_path, filename)
 
         # If an S3 bucket is configured, attempt to store input files in the bucket in a daydir


### PR DESCRIPTION
This is to prevent name clashes and make it more clear when running multiple schedulers that save off their input/output data.