### PR TITLE
Per tel class change time

### DIFF
--- a/adaptive_scheduler/interfaces.py
+++ b/adaptive_scheduler/interfaces.py
@@ -134,7 +134,7 @@ class NetworkInterface(object):
         '''
         return self.network_schedule_interface.rr_request_group_intervals_by_telescope()
 
-    def schedulable_request_set_has_changed(self):
+    def schedulable_request_set_has_changed(self, telescope_classes):
         '''True if set of schedulable requests or observations have changed
         '''
         try:
@@ -144,7 +144,7 @@ class NetworkInterface(object):
             else:
                 last_changed_check = pickle.loads(last_changed_check)
             now = datetime.utcnow()
-            last_changed = self.observation_portal_interface.get_last_changed()
+            last_changed = self.observation_portal_interface.get_last_changed(telescope_classes)
             redis.set('scheduler_last_changed_check_time', pickle.dumps(now))
             if last_changed > last_changed_check:
                 return True
@@ -206,7 +206,7 @@ class CachedInputNetworkInterface(object):
         self.json_request_group_list = input_data['json_request_group_list']
         self.resource_usage_snapshot_data = input_data['resource_usage_snapshot']
 
-    def schedulable_request_set_has_changed(self):
+    def schedulable_request_set_has_changed(self, telescope_classes):
         '''True if set of schedulable requests has changed
         '''
         return True

--- a/adaptive_scheduler/observation_portal_connections.py
+++ b/adaptive_scheduler/observation_portal_connections.py
@@ -66,12 +66,19 @@ class ObservationPortalInterface(SendMetricMixin):
 
     @timeit
     @metric_timer('requestdb.get_last_changed')
-    def get_last_changed(self):
+    def get_last_changed(self, telescope_classes=None):
         ''' Queries the observation portal for the time the last change was made to request or observation state
         :return: The datetime for the last change in observation portals models
         '''
+        last_changed_url = self.obs_portal_url + '/api/last_changed/'
+        if telescope_classes:
+            for i, telescope_class in enumerate(telescope_classes):
+                if i == 0:
+                    last_changed_url += f"?telescope_class={telescope_class}"
+                else:
+                    last_changed_url += f"&telescope_class={telescope_class}"
         try:
-            response = requests.get(self.obs_portal_url + '/api/last_changed/', headers=self.headers, timeout=180)
+            response = requests.get(last_changed_url, headers=self.headers, timeout=180)
             response.raise_for_status()
             last_changed = parse(response.json()['last_change_time'])
             last_changed = last_changed.replace(tzinfo=None)

--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -656,7 +656,7 @@ class SchedulerRunner(object):
         request_set_changed = True
         if (not self.sched_params.dry_run) and (not self.sched_params.no_weather):
             # Skipping weather checking or doing a dry run forces network/request update
-            request_set_changed = self.network_interface.schedulable_request_set_has_changed()
+            request_set_changed = self.network_interface.schedulable_request_set_has_changed(self.sched_params.telescope_classes)
 
         return network_has_changed or request_set_changed
 


### PR DESCRIPTION
This goes along with the change in observation portal with caching last_change_time per telescope class (https://github.com/observatorycontrolsystem/observation-portal/pull/194)