### PR TITLE
Fix retrieiving and using the self_guide parameter for requests

### DIFF
--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -384,7 +384,7 @@ def build_observation(reservation, semester_start, configdb_interface):
         }
 
         if configuration.guiding_config.get('mode', 'OFF') != 'OFF':
-            self_guide = getattr(configuration.extra_params, 'self_guide', False)
+            self_guide = getattr(configuration, 'extra_params', {}).get('self_guide', False)
             specific_ag = resolve_autoguider(self_guide, specific_camera,
                                              site, enclosure, telescope,
                                              configdb_interface)


### PR DESCRIPTION
setting self guiding has been broken in the scheduler for a while. I think maybe behavior of those attributes changed when switching to python3? Or else its been broken even longer than a while...