### PR TITLE
Increasing the effective priority cap since it is constraining TC req…

### DIFF
--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -561,7 +561,7 @@ class RequestGroup(EqualityMixin):
             log.warning("Unknown observation type encountered: {}. Setting effective priority to 0".format(
                 self.observation_type))
 
-        effective_priority = min(effective_priority, 32000.0) * ran
+        effective_priority = min(effective_priority, 320000.0) * ran
 
         return effective_priority
 


### PR DESCRIPTION
…uests

Nikolaus helped identify this issue where our effective priority cap at 32,000 was too low given the higher priorities that time critical requests can have. Basically all TC requests were constrained by this cap, so we weren't getting any differentiation between TC requests with different base priorities. This cap has been in place since the inception of the scheduler, but the kernel and hardware running the scheduler has been upgraded enough since then that I think it's probably safe to increase it an order of magnitude - it was in place to keep numerical stability in the solver since having too wide of a range of priorities to optimize against can cause slowness and in-solvability. I'm this change in a branch on the prod scheduler right now and so far so good, solves are still happening fast, but its possible solves will get slower if we get enough TC requests being considered at once. I choose to up it 1 order of magnitude since that perfectly encapsulates the range of base priorities we have for TC observations, plus an extra 100,000 of lee-way in case we want to submit some higher priority things in the future.