### PR TITLE
First draft of scheduler changes to support the configuration_repeats…

### DIFF
--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -385,12 +385,13 @@ class Request(EqualityMixin):
     '''
 
     def __init__(self, configurations, windows, request_id, state='PENDING',
-                 duration=0, scheduled_reservation=None):
+                 duration=0, configuration_repeats=1, scheduled_reservation=None):
         self.configurations = configurations
         self.windows = windows
         self.id = request_id
         self.state = state
         self.req_duration = duration
+        self.configuration_repeats = configuration_repeats
         self.scheduled_reservation = scheduled_reservation
 
     def get_duration(self):
@@ -762,6 +763,7 @@ class ModelBuilder(object):
             request_id=int(req_dict['id']),
             state=req_dict['state'],
             duration=req_dict['duration'],
+            configuration_repeats=req_dict['configuration_repeats'] if 'configuration_repeats' in req_dict else 1,
             scheduled_reservation=scheduled_reservation
         )
 

--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -409,6 +409,11 @@ def build_observation(reservation, semester_start, configdb_interface):
             rg_log.debug(msg, reservation.request_group.id)
         configuration_statuses.append(configuration_status)
 
+    all_configuration_statuses = []
+    for i in range(request.configuration_repeats):
+        # Duplicate the configuration_statuses for each configuration_repeat
+        all_configuration_statuses.extend(configuration_statuses)
+
     observation = {
         'site': site,
         'enclosure': enclosure,
@@ -416,7 +421,7 @@ def build_observation(reservation, semester_start, configdb_interface):
         'start': res_start.isoformat(),
         'end': res_end.isoformat(),
         'request': request.id,
-        'configuration_statuses': configuration_statuses
+        'configuration_statuses': all_configuration_statuses
     }
 
     return observation

--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -410,7 +410,7 @@ def build_observation(reservation, semester_start, configdb_interface):
         configuration_statuses.append(configuration_status)
 
     all_configuration_statuses = []
-    for i in range(request.configuration_repeats):
+    for _ in range(request.configuration_repeats):
         # Duplicate the configuration_statuses for each configuration_repeat
         all_configuration_statuses.extend(configuration_statuses)
 


### PR DESCRIPTION
… field for nodding

This simply repeats the set of "configuration_statuses" to submit for the observation based on the number of "configuration_repeats" in the Request. Configuration statuses being scheduled here are just the details like instrument name, guider name, and the configuration id they correspond with.