### PR TITLE
Get telescope_class from aperture

### DIFF
--- a/adaptive_scheduler/configdb_connections.py
+++ b/adaptive_scheduler/configdb_connections.py
@@ -323,7 +323,6 @@ class ConfigDBInterface(SendMetricMixin):
                             'tel_class': telescope_class,
                             'latitude': telescope['lat'],
                             'longitude': telescope['long'],
-                            'aperture': telescope['aperture'],
                             'horizon': telescope['horizon'],
                             'ha_limit_neg': telescope['ha_limit_neg'],
                             'ha_limit_pos': telescope['ha_limit_pos'],

--- a/adaptive_scheduler/configdb_connections.py
+++ b/adaptive_scheduler/configdb_connections.py
@@ -1,5 +1,6 @@
 import logging
 import json
+from math import floor
 from collections import defaultdict
 
 import requests
@@ -33,8 +34,8 @@ class ConfigDBInterface(SendMetricMixin):
         self.update_configdb_structures()
 
     def update_configdb_structures(self):
-        self.update_active_instruments()
         self.update_telescope_info()
+        self.update_active_instruments()
 
     def update_active_instruments(self):
         try:
@@ -95,7 +96,10 @@ class ConfigDBInterface(SendMetricMixin):
             instruments = []
             for instrument in json_results['results']:
                 split_string = instrument['__str__'].lower().split('.')
-                telescope_class = split_string[2][:3]
+                # Need to reverse the ordering of the first parts of the instrument string to get resource
+                resource = '.'.join(split_string[2], split_string[1], split_string[0])
+                # Telescope info is filled in before active instruments so this should always be available
+                telescope_class = self.telescope_info.get(resource, {}).get('tel_class', '')
                 if telescope_class in self.telescope_classes:
                     instruments.append(instrument)
             return instruments
@@ -290,6 +294,16 @@ class ConfigDBInterface(SendMetricMixin):
             raise ConfigDBError("get_all_sites failed: ConfigDB returned no results")
         return json_results['results']
 
+    @staticmethod
+    def _convert_telescope_aperture_to_string(aperture):
+        ''' This takes in a float aperture and converts it to a string of the form #m#
+            where the first # is the left side of the decimal point, and the second number
+            is the rounded right side of the decimal.
+        '''
+        left_side = floor(aperture)
+        right_side = round((aperture - left_side) * 10.0)
+        return f'{left_side}m{right_side}'
+
     def _generate_telescope_info(self):
         """Generates the structure for telescope_info using the site data from configdb"""
         telescope_info = {}
@@ -297,7 +311,7 @@ class ConfigDBInterface(SendMetricMixin):
         for site in site_data:
             for enclosure in site['enclosure_set']:
                 for telescope in enclosure['telescope_set']:
-                    telescope_class = telescope['code'][:3]
+                    telescope_class = ConfigDBInterface._convert_telescope_aperture_to_string(telescope['aperture'])
                     if not self.telescope_classes or telescope_class in self.telescope_classes:
                         name = '.'.join([telescope['code'], enclosure['code'], site['code']])
                         active = telescope['active'] and enclosure['active'] and site['active']
@@ -306,6 +320,7 @@ class ConfigDBInterface(SendMetricMixin):
                             'tel_class': telescope_class,
                             'latitude': telescope['lat'],
                             'longitude': telescope['long'],
+                            'aperture': telescope['aperture'],
                             'horizon': telescope['horizon'],
                             'ha_limit_neg': telescope['ha_limit_neg'],
                             'ha_limit_pos': telescope['ha_limit_pos'],

--- a/adaptive_scheduler/configdb_connections.py
+++ b/adaptive_scheduler/configdb_connections.py
@@ -97,7 +97,7 @@ class ConfigDBInterface(SendMetricMixin):
             for instrument in json_results['results']:
                 split_string = instrument['__str__'].lower().split('.')
                 # Need to reverse the ordering of the first parts of the instrument string to get resource
-                resource = '.'.join(split_string[2], split_string[1], split_string[0])
+                resource = '.'.join([split_string[2], split_string[1], split_string[0]])
                 # Telescope info is filled in before active instruments so this should always be available
                 telescope_class = self.telescope_info.get(resource, {}).get('tel_class', '')
                 if telescope_class in self.telescope_classes:

--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -384,12 +384,13 @@ class Request(EqualityMixin):
         state          - the initial state of the Request
     '''
 
-    def __init__(self, configurations, windows, request_id, state='PENDING',
+    def __init__(self, configurations, windows, request_id, state='PENDING', telescope_class='',
                  duration=0, configuration_repeats=1, scheduled_reservation=None):
         self.configurations = configurations
         self.windows = windows
         self.id = request_id
         self.state = state
+        self.telescope_class = telescope_class
         self.req_duration = duration
         self.configuration_repeats = configuration_repeats
         self.scheduled_reservation = scheduled_reservation
@@ -762,6 +763,7 @@ class ModelBuilder(object):
             windows=windows,
             request_id=int(req_dict['id']),
             state=req_dict['state'],
+            telescope_class=req_dict['location']['telescope_class'] if 'telescope_class' in req_dict['location'] else '',
             duration=req_dict['duration'],
             configuration_repeats=req_dict['configuration_repeats'] if 'configuration_repeats' in req_dict else 1,
             scheduled_reservation=scheduled_reservation

--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -281,13 +281,13 @@ class Scheduler(SendMetricMixin):
         unscheduled_hours_per_class = defaultdict(float)
         for reservation in not_scheduled_reservations:
             # We don't currently save telescope_class, so have to parse it from beginning of inst type
-            telescope_class = reservation.request.configurations[0].instrument_type[:3].lower()
+            telescope_class = reservation.request.telescope_class.lower()
             unscheduled_reqs_per_class[telescope_class] += 1
             unscheduled_hours_per_class[telescope_class] += (reservation.duration / 3600.0)
         total_reqs_per_class = defaultdict(int)
         total_hours_per_class = defaultdict(float)
         for reservation in to_schedule_res:
-            telescope_class = reservation.request.configurations[0].instrument_type[:3].lower()
+            telescope_class = reservation.request.telescope_class.lower()
             total_reqs_per_class[telescope_class] += 1
             total_hours_per_class[telescope_class] += (reservation.duration / 3600.0)
 

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -245,9 +245,9 @@ def split_location(location):
     return (location, location, location)
 
 
-def join_location(site, observatory, telescope):
+def join_location(site, enclosure, telescope):
     # Join on full stops
-    return "%s.%s.%s" % (telescope, observatory, site)
+    return f"{telescope}.{enclosure}.{site}"
 
 
 def timeit(method):

--- a/test/active_instruments.json
+++ b/test/active_instruments.json
@@ -1,6 +1,13 @@
 [
   {
     "telescope": "http://configdb.lco.gtn/telescopes/16/",
+    "telescope_details": {
+      "telescope_location": "tfn.aqwa.0m4a",
+      "site": "tfn",
+      "enclosure": "aqwa",
+      "telescope": "0m4a",
+      "telescope_class": "0m4"
+    },
     "__str__": "tfn.aqwa.0m4a.kb29-kb29",
     "instrument_type": {
       "allow_self_guiding": true,
@@ -171,6 +178,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.fs02-kb40",
+    "telescope_details": {
+      "telescope_location": "ogg.clma.2m0a",
+      "site": "ogg",
+      "enclosure": "clma",
+      "telescope": "2m0a",
+      "telescope_class": "2m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 12.0,
@@ -324,6 +338,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/4/",
     "__str__": "coj.doma.1m0a.fl12-ef09",
+    "telescope_details": {
+      "telescope_location": "coj.doma.1m0a",
+      "site": "coj",
+      "enclosure": "doma",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -532,6 +553,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/20/",
     "__str__": "ogg.clma.0m4b.kb27-kb27",
+    "telescope_details": {
+      "telescope_location": "ogg.clma.0m4b",
+      "site": "ogg",
+      "enclosure": "clma",
+      "telescope": "0m4b",
+      "telescope_class": "0m4"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -700,6 +728,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/7/",
     "__str__": "cpt.domb.1m0a.fl14-ef03",
+    "telescope_details": {
+      "telescope_location": "cpt.domb.1m0a",
+      "site": "cpt",
+      "enclosure": "domb",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -888,6 +923,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/5/",
     "__str__": "coj.domb.1m0a.fl11-ef10",
+    "telescope_details": {
+      "telescope_location": "coj.domb.1m0a",
+      "site": "coj",
+      "enclosure": "domb",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -1096,6 +1138,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/22/",
     "__str__": "coj.clma.0m4a.kb98-kb98",
+    "telescope_details": {
+      "telescope_location": "coj.clma.0m4a",
+      "site": "coj",
+      "enclosure": "clma",
+      "telescope": "0m4a",
+      "telescope_class": "0m4"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -1264,6 +1313,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/12/",
     "__str__": "lsc.domc.1m0a.fl04-ef08",
+    "telescope_details": {
+      "telescope_location": "lsc.domc.1m0a",
+      "site": "lsc",
+      "enclosure": "domc",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -1442,6 +1498,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/8/",
     "__str__": "cpt.domc.1m0a.fl06-ef04",
+    "telescope_details": {
+      "telescope_location": "cpt.domc.1m0a",
+      "site": "cpt",
+      "enclosure": "domc",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -1620,6 +1683,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/3/",
     "__str__": "coj.clma.2m0a.fs01-kb34",
+    "telescope_details": {
+      "telescope_location": "coj.clma.2m0a",
+      "site": "coj",
+      "enclosure": "clma",
+      "telescope": "2m0a",
+      "telescope_class": "2m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 12.0,
@@ -1778,6 +1848,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/9/",
     "__str__": "elp.doma.1m0a.fl05-ef01",
+    "telescope_details": {
+      "telescope_location": "elp.doma.1m0a",
+      "site": "elp",
+      "enclosure": "doma",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -1981,6 +2058,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.floyds01-kb42",
+    "telescope_details": {
+      "telescope_location": "ogg.clma.2m0a",
+      "site": "ogg",
+      "enclosure": "clma",
+      "telescope": "2m0a",
+      "telescope_class": "2m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 0.5,
@@ -2089,6 +2173,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.fake01-na42",
+    "telescope_details": {
+      "telescope_location": "ogg.clma.2m0a",
+      "site": "ogg",
+      "enclosure": "clma",
+      "telescope": "2m0a",
+      "telescope_class": "2m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 0.5,
@@ -2227,6 +2318,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/6/",
     "__str__": "cpt.doma.1m0a.fl16-ef02",
+    "telescope_details": {
+      "telescope_location": "cpt.doma.1m0a",
+      "site": "cpt",
+      "enclosure": "doma",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -2405,6 +2503,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/15/",
     "__str__": "sqa.doma.0m8a.kb16-kb31",
+    "telescope_details": {
+      "telescope_location": "sqa.doma.0m8a",
+      "site": "sqa",
+      "enclosure": "doma",
+      "telescope": "0m8a",
+      "telescope_class": "0m8"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -2518,6 +2623,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/15/",
     "__str__": "sqa.doma.0m8a.nres-kb35",
+    "telescope_details": {
+      "telescope_location": "sqa.doma.0m8a",
+      "site": "sqa",
+      "enclosure": "doma",
+      "telescope": "0m8a",
+      "telescope_class": "0m8"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 0.5,
@@ -2601,6 +2713,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/11/",
     "__str__": "lsc.domb.1m0a.fl03-ef07",
+    "telescope_details": {
+      "telescope_location": "lsc.domb.1m0a",
+      "site": "lsc",
+      "enclosure": "domb",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,
@@ -2789,6 +2908,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/11/",
     "__str__": "lsc.domb.1m0a.nres01-ak01",
+    "telescope_details": {
+      "telescope_location": "lsc.domb.1m0a",
+      "site": "lsc",
+      "enclosure": "domb",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 0.5,
@@ -2857,6 +2983,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/3/",
     "__str__": "coj.clma.2m0a.floyds02-kb37",
+    "telescope_details": {
+      "telescope_location": "coj.clma.2m0a",
+      "site": "coj",
+      "enclosure": "clma",
+      "telescope": "2m0a",
+      "telescope_class": "2m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 0.5,
@@ -2965,6 +3098,13 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/10/",
     "__str__": "lsc.doma.1m0a.fl15-ef06",
+    "telescope_details": {
+      "telescope_location": "lsc.doma.1m0a",
+      "site": "lsc",
+      "enclosure": "doma",
+      "telescope": "1m0a",
+      "telescope_class": "1m0"
+    },
     "instrument_type": {
       "allow_self_guiding": true,
       "fixed_overhead_per_exposure": 1.0,

--- a/test/active_instruments.json
+++ b/test/active_instruments.json
@@ -2,7 +2,7 @@
   {
     "telescope": "http://configdb.lco.gtn/telescopes/16/",
     "telescope_details": {
-      "telescope_location": "tfn.aqwa.0m4a",
+      "telescope_location": "0m4a.aqwa.tfn",
       "site": "tfn",
       "enclosure": "aqwa",
       "telescope": "0m4a",
@@ -179,7 +179,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.fs02-kb40",
     "telescope_details": {
-      "telescope_location": "ogg.clma.2m0a",
+      "telescope_location": "2m0a.clma.ogg",
       "site": "ogg",
       "enclosure": "clma",
       "telescope": "2m0a",
@@ -339,7 +339,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/4/",
     "__str__": "coj.doma.1m0a.fl12-ef09",
     "telescope_details": {
-      "telescope_location": "coj.doma.1m0a",
+      "telescope_location": "1m0a.doma.coj",
       "site": "coj",
       "enclosure": "doma",
       "telescope": "1m0a",
@@ -554,7 +554,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/20/",
     "__str__": "ogg.clma.0m4b.kb27-kb27",
     "telescope_details": {
-      "telescope_location": "ogg.clma.0m4b",
+      "telescope_location": "o0m4b.clma.ogg",
       "site": "ogg",
       "enclosure": "clma",
       "telescope": "0m4b",
@@ -729,7 +729,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/7/",
     "__str__": "cpt.domb.1m0a.fl14-ef03",
     "telescope_details": {
-      "telescope_location": "cpt.domb.1m0a",
+      "telescope_location": "1m0a.domb.cpt",
       "site": "cpt",
       "enclosure": "domb",
       "telescope": "1m0a",
@@ -924,7 +924,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/5/",
     "__str__": "coj.domb.1m0a.fl11-ef10",
     "telescope_details": {
-      "telescope_location": "coj.domb.1m0a",
+      "telescope_location": "1m0a.domb.coj",
       "site": "coj",
       "enclosure": "domb",
       "telescope": "1m0a",
@@ -1139,7 +1139,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/22/",
     "__str__": "coj.clma.0m4a.kb98-kb98",
     "telescope_details": {
-      "telescope_location": "coj.clma.0m4a",
+      "telescope_location": "0m4a.clma.coj",
       "site": "coj",
       "enclosure": "clma",
       "telescope": "0m4a",
@@ -1314,7 +1314,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/12/",
     "__str__": "lsc.domc.1m0a.fl04-ef08",
     "telescope_details": {
-      "telescope_location": "lsc.domc.1m0a",
+      "telescope_location": "1m0a.domc.lsc",
       "site": "lsc",
       "enclosure": "domc",
       "telescope": "1m0a",
@@ -1499,7 +1499,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/8/",
     "__str__": "cpt.domc.1m0a.fl06-ef04",
     "telescope_details": {
-      "telescope_location": "cpt.domc.1m0a",
+      "telescope_location": "1m0a.domc.cpt",
       "site": "cpt",
       "enclosure": "domc",
       "telescope": "1m0a",
@@ -1684,7 +1684,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/3/",
     "__str__": "coj.clma.2m0a.fs01-kb34",
     "telescope_details": {
-      "telescope_location": "coj.clma.2m0a",
+      "telescope_location": "2m0a.clma.coj",
       "site": "coj",
       "enclosure": "clma",
       "telescope": "2m0a",
@@ -1849,7 +1849,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/9/",
     "__str__": "elp.doma.1m0a.fl05-ef01",
     "telescope_details": {
-      "telescope_location": "elp.doma.1m0a",
+      "telescope_location": "1m0a.doma.elp",
       "site": "elp",
       "enclosure": "doma",
       "telescope": "1m0a",
@@ -2059,7 +2059,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.floyds01-kb42",
     "telescope_details": {
-      "telescope_location": "ogg.clma.2m0a",
+      "telescope_location": "2m0a.clma.ogg",
       "site": "ogg",
       "enclosure": "clma",
       "telescope": "2m0a",
@@ -2174,7 +2174,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/14/",
     "__str__": "ogg.clma.2m0a.fake01-na42",
     "telescope_details": {
-      "telescope_location": "ogg.clma.2m0a",
+      "telescope_location": "2m0a.clma.ogg",
       "site": "ogg",
       "enclosure": "clma",
       "telescope": "2m0a",
@@ -2319,7 +2319,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/6/",
     "__str__": "cpt.doma.1m0a.fl16-ef02",
     "telescope_details": {
-      "telescope_location": "cpt.doma.1m0a",
+      "telescope_location": "1m0a.doma.cpt",
       "site": "cpt",
       "enclosure": "doma",
       "telescope": "1m0a",
@@ -2504,7 +2504,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/15/",
     "__str__": "sqa.doma.0m8a.kb16-kb31",
     "telescope_details": {
-      "telescope_location": "sqa.doma.0m8a",
+      "telescope_location": "0m8a.doma.sqa",
       "site": "sqa",
       "enclosure": "doma",
       "telescope": "0m8a",
@@ -2624,7 +2624,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/15/",
     "__str__": "sqa.doma.0m8a.nres-kb35",
     "telescope_details": {
-      "telescope_location": "sqa.doma.0m8a",
+      "telescope_location": "0m8a.doma.sqa",
       "site": "sqa",
       "enclosure": "doma",
       "telescope": "0m8a",
@@ -2714,7 +2714,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/11/",
     "__str__": "lsc.domb.1m0a.fl03-ef07",
     "telescope_details": {
-      "telescope_location": "lsc.domb.1m0a",
+      "telescope_location": "1m0a.domb.lsc",
       "site": "lsc",
       "enclosure": "domb",
       "telescope": "1m0a",
@@ -2909,7 +2909,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/11/",
     "__str__": "lsc.domb.1m0a.nres01-ak01",
     "telescope_details": {
-      "telescope_location": "lsc.domb.1m0a",
+      "telescope_location": "1m0a.domb.lsc",
       "site": "lsc",
       "enclosure": "domb",
       "telescope": "1m0a",
@@ -2984,7 +2984,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/3/",
     "__str__": "coj.clma.2m0a.floyds02-kb37",
     "telescope_details": {
-      "telescope_location": "coj.clma.2m0a",
+      "telescope_location": "2m0a.clma.coj",
       "site": "coj",
       "enclosure": "clma",
       "telescope": "2m0a",
@@ -3099,7 +3099,7 @@
     "telescope": "http://configdb.lco.gtn/telescopes/10/",
     "__str__": "lsc.doma.1m0a.fl15-ef06",
     "telescope_details": {
-      "telescope_location": "lsc.doma.1m0a",
+      "telescope_location": "1m0a.doma.lsc",
       "site": "lsc",
       "enclosure": "doma",
       "telescope": "1m0a",


### PR DESCRIPTION
Forgot to change this with the configdb updates adding aperture. Things still work for us since our telescope codes == telescope_class but this broke for a new user that didn't have that assumption.

This is a minimal fix to use the aperture to get the telescope_class, but longer term I think we can cut down the two separate calls to get sites and get instruments in configdb into just a single call getting the sites and pulling out what we need to save some bandwidth and time.