### PR TITLE
Fix autoguider resolution to use the fully qualified telescope location

### DIFF
--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -353,21 +353,21 @@ def log_info_dry_run(msg, dry_run):
     log.info(msg)
 
 
-def resolve_instrument(instrument_type, site, obs, tel, configdb_interface):
+def resolve_instrument(instrument_type, site, enc, tel, configdb_interface):
     """Determine the specific camera name for a given site.
 
     If a non-generic name is provided, we just pass it through and assume it's ok.
     """
     try:
-        specific_camera = configdb_interface.get_specific_instrument(instrument_type, site, obs, tel)
+        specific_camera = configdb_interface.get_specific_instrument(instrument_type, site, enc, tel)
     except ConfigDBError:
-        msg = "Couldn't find any instrument for '{}' at {}.{}.{}".format(instrument_type, tel, obs, site)
+        msg = "Couldn't find any instrument for '{}' at {}.{}.{}".format(instrument_type, tel, enc, site)
         raise InstrumentResolutionError(msg)
 
     return specific_camera
 
 
-def resolve_autoguider(self_guide, instrument_name, site, enc, tel, configdb_interface):
+def resolve_autoguider(self_guide, instrument_code, site, enc, tel, configdb_interface):
     """Determine the specific autoguider for a given site.
 
     If a specific name is provided, pass through and return it.
@@ -376,9 +376,9 @@ def resolve_autoguider(self_guide, instrument_name, site, enc, tel, configdb_int
     """
 
     try:
-        ag_match = configdb_interface.get_autoguider_for_instrument(instrument_name, self_guide)
+        ag_match = configdb_interface.get_autoguider_for_instrument(instrument_code, self_guide, site, enc, tel)
     except ConfigDBError:
-        msg = "Couldn't find any autoguider for '{}' at {}.{}.{}".format(instrument_name, tel, enc, site)
+        msg = "Couldn't find any autoguider for '{}' at {}.{}.{}".format(instrument_code, tel, enc, site)
         raise InstrumentResolutionError(msg)
 
     return ag_match

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -89,36 +89,36 @@ class TestObservations(object):
 
     def test_scicam_instrument_resolves_to_a_specific_camera(self):
         instrument_type = '1M0-SCICAM-SINISTRO'
-        site, obs, tel = ('lsc', 'doma', '1m0a')
-        received = resolve_instrument(instrument_type, site, obs, tel, self.configdb_interface)
+        site, enc, tel = ('lsc', 'doma', '1m0a')
+        received = resolve_instrument(instrument_type, site, enc, tel, self.configdb_interface)
         assert received == 'fl15'
 
     def test_no_matching_instrument_raises_an_exception(self):
         with pytest.raises(InstrumentResolutionError):
             instrument_type = '1M0-SCICAM-SINISTRO'
-            site, obs, tel = ('looloo', 'doma', '1m0a')
-            resolve_instrument(instrument_type, site, obs, tel, self.configdb_interface)
+            site, enc, tel = ('looloo', 'doma', '1m0a')
+            resolve_instrument(instrument_type, site, enc, tel, self.configdb_interface)
 
     def test_scicam_autoguider_resolves_to_primary_instrument(self):
         self_guide = True
-        specific_inst_name = 'fl15'
-        site, obs, tel = ('lsc', 'doma', '1m0a')
-        received = resolve_autoguider(self_guide, specific_inst_name, site, obs, tel, self.configdb_interface)
+        specific_inst_code = 'fl15'
+        site, enc, tel = ('lsc', 'doma', '1m0a')
+        received = resolve_autoguider(self_guide, specific_inst_code, site, enc, tel, self.configdb_interface)
         assert received == 'fl15'
 
     def test_no_autoguider_resolves_to_preferred_autoguider(self):
         self_guide = False
-        inst_name = 'fl15'
-        site, obs, tel = ('lsc', 'doma', '1m0a')
-        received = resolve_autoguider(self_guide, inst_name, site, obs, tel, self.configdb_interface)
+        specific_inst_code = 'fl15'
+        site, enc, tel = ('lsc', 'doma', '1m0a')
+        received = resolve_autoguider(self_guide, specific_inst_code, site, enc, tel, self.configdb_interface)
         assert received == 'ef06'
 
     def test_no_matching_autoguider_raises_an_exception(self):
         with pytest.raises(InstrumentResolutionError):
             self_guide = True
-            inst_name = 'abcd'
-            site, obs, tel = ('looloo', 'doma', '1m0a')
-            resolve_autoguider(self_guide, inst_name, site, obs, tel, self.configdb_interface)
+            specific_inst_code = 'abcd'
+            site, enc, tel = ('looloo', 'doma', '1m0a')
+            resolve_autoguider(self_guide, specific_inst_code, site, enc, tel, self.configdb_interface)
 
 
 class TestObservationInteractions(object):


### PR DESCRIPTION
Fix for the bug Daniel reported. For nres instruments where we use the same code for multiple instruments, when neither one is SCHEDULABLE, it is undefined which autoguider it will resolve to right now. This changes the logic to include the fully qualified telescope location when trying to resolve the autoguider, which is what we do when trying to resolve the instrument. I don't really see a reason not to do this, since we have the location as where the reservation was scheduled. 