### PR TITLE
Fix scheduling of satellite observations

### DIFF
--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -280,12 +280,12 @@ class SatelliteTarget(Target):
 
     def __init__(self, *initial_data, **kwargs):
         required_fields = ('altitude', 'azimuth', 'diff_altitude_rate', 'diff_azimith_rate', 'diff_epoch',
-                           'diff_azimuth_acceleration', 'diff_altitude_acceleration')
+                           'diff_altitude_acceleration', 'diff_azimuth_acceleration')
         super().__init__(required_fields, *initial_data, **kwargs)
 
     def in_rise_set_format(self):
-        target_dict = make_satellite_target(self.altitude, self.azimuth, self.diff_pitch_rate, self.diff_roll_rate,
-                                            self.diff_pitch_acceleration, self.diff_roll_acceleration,
+        target_dict = make_satellite_target(self.altitude, self.azimuth, self.diff_altitude_rate, self.diff_azimuth_rate,
+                                            self.diff_altitude_acceleration, self.diff_azimuth_acceleration,
                                             self.diff_epoch)
 
         return target_dict

--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -279,7 +279,7 @@ class SatelliteTarget(Target):
     '''
 
     def __init__(self, *initial_data, **kwargs):
-        required_fields = ('altitude', 'azimuth', 'diff_altitude_rate', 'diff_azimith_rate', 'diff_epoch',
+        required_fields = ('altitude', 'azimuth', 'diff_altitude_rate', 'diff_azimuth_rate', 'diff_epoch',
                            'diff_altitude_acceleration', 'diff_azimuth_acceleration')
         super().__init__(required_fields, *initial_data, **kwargs)
 

--- a/adaptive_scheduler/models.py
+++ b/adaptive_scheduler/models.py
@@ -279,14 +279,14 @@ class SatelliteTarget(Target):
     '''
 
     def __init__(self, *initial_data, **kwargs):
-        required_fields = ('altitude', 'azimuth', 'diff_pitch_rate', 'diff_roll_rate', 'diff_epoch_rate',
-                           'diff_roll_acceleration', 'diff_pitch_acceleration')
+        required_fields = ('altitude', 'azimuth', 'diff_altitude_rate', 'diff_azimith_rate', 'diff_epoch',
+                           'diff_azimuth_acceleration', 'diff_altitude_acceleration')
         super().__init__(required_fields, *initial_data, **kwargs)
 
     def in_rise_set_format(self):
         target_dict = make_satellite_target(self.altitude, self.azimuth, self.diff_pitch_rate, self.diff_roll_rate,
                                             self.diff_pitch_acceleration, self.diff_roll_acceleration,
-                                            self.diff_epoch_rate)
+                                            self.diff_epoch)
 
         return target_dict
 


### PR DESCRIPTION
The fields expected in a satellite target in the obs portal did not match those in the scheduler, so the scheduler would throw an error when attempting to schedule requests with target types of satellite.

This PR just adjusts the fields to match what the obs portal calls its [parameters](https://github.com/observatorycontrolsystem/observation-portal/blob/9c668022c25a8efdfa291310ae409fe7e6431e72/observation_portal/requestgroups/target_helpers.py#L102). 

To test this, I have this branch of the scheduler running on dev and I submitted a [request](http://observation-portal-dev.lco.gtn/requests/2628181) to the portal and it was successfully scheduled.