### PR TITLE
Fix problem with completed observations blocking scheduling new ones

### DIFF
--- a/adaptive_scheduler/observations.py
+++ b/adaptive_scheduler/observations.py
@@ -339,8 +339,13 @@ class ObservationScheduleInterface(object):
         cutoff_dt = starts_before
         for observation in schedule:
             if observation['start'] < starts_before < observation['end']:
-                if observation['end'] > cutoff_dt and observation['state'] in ['PENDING', 'IN_PROGRESS']:
-                    cutoff_dt = observation['end']
+                if observation['end'] > cutoff_dt:
+                    if observation['state'] in ['PENDING', 'IN_PROGRESS']:
+                        cutoff_dt = observation['end']
+                    elif observation['state'] == 'COMPLETED':
+                        # If the observation is already completed, set its end time so we don't block
+                        # scheduling other observations using that end time as a reason
+                        observation['end'] = starts_before
 
         running = [b for b in schedule if b['start'] < cutoff_dt]
 


### PR DESCRIPTION
This came from a problem Nikolaus reported last month: https://lcogt.slack.com/archives/C0ANPF49F/p1749233652771689. 

The problem was that completed observations that finished early, such that their end time was still in the future past the current scheduling cutoff, would block other requests from getting scheduled on that resource until their scheduled end time, rather than allowing other requests to get scheduled there since it finished early. I believe this change should fix that behavior setting the internal observation end time for completed "running" observations to be the scheduling cutoff time for that run. We need to still have the completed observations in that list since that is used for other things like preventing a request that just completed from getting rescheduled that same run it completed in.